### PR TITLE
Allow comments in JSON files

### DIFF
--- a/lib/ace/mode/json/json_parse.js
+++ b/lib/ace/mode/json/json_parse.js
@@ -189,10 +189,24 @@ define(function(require, exports, module) {
 
         white = function () {
 
-// Skip whitespace.
+// Skip whitespace and comments /**/.
 
-            while (ch && ch <= ' ') {
-                next();
+            while (true) {
+                while (ch && ch <= ' ') {
+                    next();
+                }
+
+                if (ch && ch === '/' && text.charAt(at) === '*') {
+                    next('/');
+                    next('*');
+                    while (ch && ch !== '*') {
+                        next();
+                    }
+                    if (ch === '*' && text.charAt(at) === '/') {
+                        next('*');
+                        next('/');
+                    }
+                } else break;
             }
         },
 


### PR DESCRIPTION
*Issue #, if available:*
JSON highlight rules allow comments '/**/' but the worker does not.

*Description of changes:*
The patch adds this feature to JSON worker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Pull Request Checklist:
* [x] No backwards incompatible changes were made to Ace's public interface which is defined through the main typings file (`ace.d.ts`) and its references:
    * https://github.com/ajaxorg/ace/blob/master/ace.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-modes.d.ts 
    * https://github.com/ajaxorg/ace/blob/master/ace-extensions.d.ts

